### PR TITLE
Allow building with singletons-2.3

### DIFF
--- a/Data/Nat.hs
+++ b/Data/Nat.hs
@@ -2,7 +2,7 @@
   UndecidableInstances, ScopedTypeVariables, DataKinds,
   FlexibleInstances, GADTs, TypeFamilies, TemplateHaskell,
   InstanceSigs, TypeOperators, PolyKinds, StandaloneDeriving,
-  FlexibleContexts, AllowAmbiguousTypes #-}
+  FlexibleContexts, AllowAmbiguousTypes, CPP, OverloadedStrings #-}
 
 module Data.Nat (
     Nat(..)
@@ -58,7 +58,11 @@ instance Eq (SNat n) where
 instance Ord (SNat n) where
   compare _ _ = EQ
 
+#if MIN_VERSION_singletons(2,3,0)
+instance PNum Nat where
+#else
 instance PNum ('Proxy :: Proxy Nat) where
+#endif
   type a :+ b = NatPlus a b
   type a :- b = NatMinus a b
   type a :* b = NatMul a b

--- a/singleton-nats.cabal
+++ b/singleton-nats.cabal
@@ -14,7 +14,7 @@ copyright:           2015 András Kovács
 
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 8.0.1
+tested-with:         GHC == 8.0.1, GHC == 8.2.1
 
 source-repository head
   type: git
@@ -26,6 +26,6 @@ library
 
   build-depends:
     base >=4.8.1.0 && <5,
-    singletons >= 2.2 && < 2.3
+    singletons >= 2.2 && < 2.4
 
   default-language:    Haskell2010


### PR DESCRIPTION
Two relatively minor changes are required to make `singleton-nats` compile with `singletons-2.3`:

* `Demote Symbol` is now `Text` instead of `String`, so I had to enable `OverloadedStrings` as a result.
* `PNum` no longer uses a `Proxy` hack due to the advent of `TypeInType`, so one has to write `PNum Nat` instead of `PNum ('Proxy :: Proxy Nat)`.

I opted to use CPP to make the latter change to keep backwards compatibility with GHC 8.0.1. I'm not sure if that's how you'd prefer this change to be made, however. If you'd rather avoid CPP and just support `singletons-2.3`/GHC 8.2.1 as the minimum, I'd be willing to update this PR accordingly.