### PR TITLE
Allow building with singletons-2.4

### DIFF
--- a/singleton-nats.cabal
+++ b/singleton-nats.cabal
@@ -14,7 +14,7 @@ copyright:           2015 András Kovács
 
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 8.0.1, GHC == 8.2.1
+tested-with:         GHC == 8.0.1, GHC == 8.2.1, GHC == 8.4.1
 
 source-repository head
   type: git
@@ -26,6 +26,6 @@ library
 
   build-depends:
     base >=4.8.1.0 && <5,
-    singletons >= 2.2 && < 2.4
+    singletons >= 2.2 && < 2.5
 
   default-language:    Haskell2010


### PR DESCRIPTION
`singletons-2.4` made some changes that require changing `singleton-nats` to fix:

* Generated code now uses `EmptyCase`.
* Deriving `Show` within the `singletons` function now generates `Show` instances for the `Sing` instance as well, so the derived `Show` instance for `SNat` is no longer needed.
* The naming conventions for promoted/singled infix functions have changed to not use colons anymore.

I opted to use CPP to make the latter change to keep backwards compatibility with older GHCs. I'm not sure if that's how you'd prefer this change to be made, however. If you'd rather avoid CPP and just support `singletons-2.4`/GHC 8.4.1 as the minimum, I'd be willing to update this PR accordingly.