### PR TITLE
Allow building with singletons-2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# next [????.??.??]
+* Allow `singletons-2.5`.
+
 # 0.4.1 [2018.05.02]
 * Add a `Num Nat` instance.
 * Implement `signum` in the `PNum`/`SNum` instances for `Nat`.

--- a/Data/Nat.hs
+++ b/Data/Nat.hs
@@ -4,6 +4,9 @@
   InstanceSigs, TypeOperators, PolyKinds, StandaloneDeriving,
   FlexibleContexts, AllowAmbiguousTypes, CPP, OverloadedStrings,
   EmptyCase #-}
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE QuantifiedConstraints #-}
+#endif
 
 module Data.Nat (
     Nat(..)

--- a/singleton-nats.cabal
+++ b/singleton-nats.cabal
@@ -26,7 +26,7 @@ library
 
   build-depends:
     base >=4.8.1.0 && <5,
-    singletons >= 2.2 && < 2.5
+    singletons >= 2.2 && < 2.6
 
   default-language:    Haskell2010
   ghc-options:         -Wall -Wno-unticked-promoted-constructors


### PR DESCRIPTION
The only code change necessary to accommodate `singletons-2.5` is conditionally enabling `QuantifiedConstraints` with CPP, since derived `Show` instances now make use of a quantified constraint synonym.